### PR TITLE
Autofs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,8 +24,7 @@
 use_systemd_mounts: false
 use_autofs_mounts: false
 systemd_mounts: {}
-autofs_mounts: {}
-autofs_mounts_enabled: {}
+autofs_maps: {}
 systemd_mounts_enabled: []
 
 systemd_mounts_manage_service: {}

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,7 +12,7 @@
 #* handlers are run on mounts that have the 'automount' directive set to true.
 #*
 #* **NOTE**: systemd uses a dash ('-') as a directory separator. Directories
-#* that incldue dashes in their path need to be escaped according to the 
+#* that incldue dashes in their path need to be escaped according to the
 #* systemd-escape rules (man systemd-escape).
 #*
 
@@ -22,17 +22,23 @@
   when: systemd_mounts_manage_service
 
 - name: Start systemd mount
-  command: systemctl start "{{ item.value.mount[1:] | replace('-', '\\x2d') | replace('/', "-") }}.mount"
+  systemd:
+    name: "{{ item.value.mount[1:] | replace('-', '\\x2d') | replace('/', \"-\") }}.mount"
+    state: started
   with_dict: "{{ systemd_mounts }}"
   when: systemd_mounts_manage_service
 
 - name: Start systemd automount
-  command: systemctl start "{{ item.value.mount[1:] | replace('-', '\\x2d') | replace('/', "-") }}.automount"
+  systemd:
+    name: "{{ item.value.mount[1:] | replace('-', '\\x2d') | replace('/', \"-\") }}.automount"
+    state: started
   with_dict: "{{ systemd_mounts }}"
   when: systemd_mounts_manage_service
 
 - name: Enable systemd mount
-  command: systemctl enable "{{ item.value.mount[1:] | replace('-', '\\x2d') | replace('/', "-") }}.mount"
+  systemd:
+    name: "{{ item.value.mount[1:] | replace('-', '\\x2d') | replace('/', \"-\") }}.mount"
+    enabled: yes
   with_dict: "{{ systemd_mounts }}"
   notify:
     - Reload systemd
@@ -40,7 +46,9 @@
   when: item.value.automount == false
 
 - name: Enable systemd automount
-  command: systemctl enable "{{ item.value.mount[1:] | replace('-', '\\x2d') | replace('/', "-") }}.automount"
+  systemd:
+    name: "{{ item.value.mount[1:] | replace('-', '\\x2d') | replace('/', \"-\") }}.automount"
+    enabled: yes
   with_dict: "{{ systemd_mounts }}"
   notify:
     - Reload systemd

--- a/tasks/autofs_mounts.yml
+++ b/tasks/autofs_mounts.yml
@@ -45,7 +45,8 @@
   template:
     src: auto.master.j2
     dest: /etc/auto.master
-
+  notify:
+    - Reload autofs
 - name: Create map-files
   template:
     src: auto.mount.j2

--- a/tasks/autofs_mounts.yml
+++ b/tasks/autofs_mounts.yml
@@ -32,7 +32,7 @@
 # Start the autofs service
 #
 - name: AUTOFS MOUNT | Enable Autofs and dependencies
-  systemctl:
+  service:
     name: "{{item}}"
     state: started
   with_items:

--- a/tasks/autofs_mounts.yml
+++ b/tasks/autofs_mounts.yml
@@ -28,13 +28,11 @@
     state: installed
   with_items: "{{ autofs_mount_packages }}"
 
-#
-# Start the autofs service
-#
 - name: AUTOFS MOUNT | Enable Autofs and dependencies
   service:
     name: "{{item}}"
     state: started
+    enabled: yes
   with_items:
     - nfs-secure
     - autofs

--- a/tasks/autofs_mounts.yml
+++ b/tasks/autofs_mounts.yml
@@ -39,23 +39,17 @@
     - nfs-secure
     - autofs
 
-#
-# tasks for mounts
-#
-- name: AUTOFS MOUNT | Add map file(s) to auto.master template
+# tasks for mounts, v2
+
+- name: Create auto.master and add map-files
   template:
     src: auto.master.j2
-    dest: "/etc/auto.master.d/{{ item.value.mount[1:] | replace('/', '-') }}.mount"
-  with_dict: "{{ autofs_mounts }}"
-  notify:
-    - Reload autofs
-  when: item.key is defined and item.key in autofs_mounts_enabled
+    dest: /etc/auto.master
 
-- name: AUTOFS MOUNT | Add automount map
+- name: Create map-files
   template:
     src: auto.mount.j2
-    dest: "/etc/auto.{{ item.value.mount[1:] | replace('/', '-') }}"
-  with_dict: "{{ autofs_mounts }}"
+    dest: "/etc/auto.{{item.key}}"
+  with_dict: "{{ autofs_maps }}"
   notify:
     - Reload autofs
-  when: item.key is defined and item.key in autofs_mounts_enabled and item.value.automount

--- a/tasks/autofs_mounts.yml
+++ b/tasks/autofs_mounts.yml
@@ -58,4 +58,4 @@
   with_dict: "{{ autofs_mounts }}"
   notify:
     - Reload autofs
-  when: item.key is defined and item.key in autofs_mounts_enabled and item.value.automount is true
+  when: item.key is defined and item.key in autofs_mounts_enabled and item.value.automount

--- a/templates/auto.master.j2
+++ b/templates/auto.master.j2
@@ -1,5 +1,5 @@
 {{ ansible_managed | comment }}
 
 {% for item in autofs_maps %}
-{{ item.path }} /etc/auto.{{ item.key | lower }} -{{ item.value.options | join(",") }}
+{{ item.value.path }} /etc/auto.{{ item.key | lower }} -{{ item.value.options | join(",") }}
 {% endfor %}

--- a/templates/auto.master.j2
+++ b/templates/auto.master.j2
@@ -1,5 +1,5 @@
 {{ ansible_managed | comment }}
 
-{% for item in autofs_maps %}
-{{ item.value.path }} /etc/auto.{{ item.key | lower }} -{{ item.value.options | join(",") }}
+{% for key, value in autofs_maps.iteritems() %}
+{{ value.path }} /etc/auto.{{ key | lower }} -{{ value.options | join(",") }}
 {% endfor %}

--- a/templates/auto.master.j2
+++ b/templates/auto.master.j2
@@ -1,5 +1,5 @@
-#
-# {{ ansible_managed }}
-#
+{{ ansible_managed | comment }}
 
-{{ item.key | lower }} /etc/auto.{{ item.key | lower }}
+{% for item in autofs_maps %}
+{{ item.path }} /etc/auto.{{ item.key | lower }} -{{ item.value.options | join(",") }}
+{% endfor %}

--- a/templates/auto.mount.j2
+++ b/templates/auto.mount.j2
@@ -1,5 +1,5 @@
 {{ ansible_managed | comment }}
 
-{% for inner in item %}
+{% for inner in item.value.mounts %}
 {{ inner.value.mount }} -{{ inner.value.options | join(",") }} {{ inner.value.share }}
 {% endfor %}

--- a/templates/auto.mount.j2
+++ b/templates/auto.mount.j2
@@ -1,5 +1,5 @@
 {{ ansible_managed | comment }}
 
 {% for inner in item.value.mounts %}
-{{ inner.value.mount }} -{{ inner.value.options | join(",") }} {{ inner.value.share }}
+{{ inner.mount }} -{{ inner.options | join(",") }} {{ inner.share }}
 {% endfor %}

--- a/templates/auto.mount.j2
+++ b/templates/auto.mount.j2
@@ -1,5 +1,5 @@
-#
-# {{ ansible_managed }}
-#
+{{ ansible_managed | comment }}
 
-{{ item.value.mount[1:] }} {{ item.value.options | join(",") }} {{ item.value.share }}
+{% for inner in item %}
+{{ inner.value.mount }} -{{ inner.value.options | join(",") }} {{ inner.value.share }}
+{% endfor %}


### PR DESCRIPTION
Hello,
thank you very much for creating this role! To use it, I had to made some changes which I think might be useful:
- Small changes: Replaced systemctl module (first commit), changed 'xyz is true' => 'xyz', added dashes in front of options in auto.xyz
- The "big" change consists of allowing for multiple mounts in a single map file. This has some advantages (you can for example specify common options in the auto.master file).

I tested this on fedora 27 with nfs.
An example variables file would look like this:
```
use_autofs_mounts: true
autofs_maps:
  home: # Leads to creation of auto.home
    options: ["async","intr","nosuid","rsize=32768","wsize=32768"]
    path: /net/cip/auto/home # and an entry /net/cip/auto/home /etc/auto.home -$options in auto.master
    mounts:
     - share: "fs-home:/cip/home/&"
       mount: "*" # mount user-homedirs as they're accessing them ( ln -s /net/cip/auto/home /home )
       options:
         - hard
  rest: # Leads to creation of auto.rest
    options: ["async","intr","nosuid","rsize=32768","wsize=32768"]
    path: /net/cip/auto #and an entry /net/cip/auto /etc/cip/auto.rest -$options
    mounts:
     - share: "fs-all:/cip/opt"
       mount: "opt" # mount /net/cip/auto/opt fs-all:/cip/opt
       options:
         - soft
     - share: "fs-all:/cip/scratch"
       mount: "scratch" # mount /net/cip/auto/scratch fs-all:/cip/scratch
       options:
         - hard
```
Best,
Philip