### PR TITLE
folder creation unnecessary for systemd mounts

### DIFF
--- a/tasks/systemd_mounts.yml
+++ b/tasks/systemd_mounts.yml
@@ -34,12 +34,6 @@
 # tasks for mounts
 # systemd uses - for dir separator, so dirs with dashes need escaped according to systemd-escape rules
 #
-- name: SYSTEMD MOUNT | Create mountpoints in filesystem
-  file:
-    path: "{{ item.value.mount }}"
-    state: directory
-  with_dict: "{{ systemd_mounts }}"
-  when: item.key in systemd_mounts_enabled
 
 - name: SYSTEMD MOUNT | Setup systemd Service for mountpoints
   template:


### PR DESCRIPTION
Tested this, it works.
Having the task there causes failure when mount is in use, ansible attempts to create directory and can't (but doesn't need to anyway)
