### PR TITLE
removed nfs-secure

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -60,10 +60,8 @@
   systemd:
     name: autofs
     state: reloaded
-  when: autofs_mounts_manage_service
 
 - name: Restart autofs
   systemd:
     name: autofs
     state: restarted
-  when: autofs_mounts_manage_service

--- a/tasks/autofs_mounts.yml
+++ b/tasks/autofs_mounts.yml
@@ -34,7 +34,6 @@
     state: started
     enabled: yes
   with_items:
-    - nfs-secure
     - autofs
 
 # tasks for mounts, v2

--- a/templates/auto.master.j2
+++ b/templates/auto.master.j2
@@ -1,5 +1,5 @@
 {{ ansible_managed | comment }}
 
-{% for key, value in autofs_maps.iteritems() %}
-{{ value.path }} /etc/auto.{{ key | lower }} -{{ value.options | join(",") }}
+{% for mount in autofs_maps | dict2items() %}
+{{ mount.value.path }} /etc/auto.{{ mount.key | lower }} -{{ mount.value.options | join(",") }}
 {% endfor %}

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -1,0 +1,14 @@
+---
+systemd_automount_os_supported: true
+autofs_automount_os_supported: true
+
+systemd_mount_packages:
+  - cifs-utils
+  - nfs-utils
+  - nfs4-acl-tools
+
+autofs_mount_packages:
+  - cifs-utils
+  - nfs-utils
+  - nfs4-acl-tools
+  - autofs


### PR DESCRIPTION
Hey,
nfs-secure is a static unit, meaning that it does not specify an [Install] Section and isn't required by any target. Instead it is activated by nfs-client.target on the client-side. Learned from this thread: https://learn.redhat.com/t5/Storage/No-more-nfs-secure-server/td-p/4571

I found that enabling autofs is sufficient if using autofs mounts. Not tested with systemd-mounts.