### PR TITLE
Hopefully fixing some dependency cycles

### DIFF
--- a/templates/systemd.automount.j2
+++ b/templates/systemd.automount.j2
@@ -1,6 +1,7 @@
 [Unit]
 Description=Automount {{ item.key }}
-After=network.target multi-user.target
+After=remote-fs-pre.target network-online.target network.target
+Before=umount.target remote-fs.target
 
 [Automount]
 Where={{ item.value.mount }}

--- a/templates/systemd.mount.j2
+++ b/templates/systemd.mount.j2
@@ -1,6 +1,7 @@
 [Unit]
 Description=Mount {{ item.key }}
-After=network.target multi-user.target
+After=remote-fs-pre.target network-online.target network.target
+Before=umount.target remote-fs.target
 
 [Mount]
 What={{ item.value.share }}


### PR DESCRIPTION
There's been instances where mounts created by these templates result in dependency cycles. I've removed the multi-user.target dep and replaced it with exclusively network related deps based on auto generated fstab units. I'm hoping that this'll cut down on instances of dependency cycles and the issues that causes. 