### PR TITLE
Adding in host specific mounts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,8 +24,10 @@
 use_systemd_mounts: false
 use_autofs_mounts: false
 systemd_mounts: {}
+host_systemd_mounts: {}
 autofs_maps: {}
 systemd_mounts_enabled: []
+host_systemd_mounts_enabled: []
 
 systemd_mounts_manage_service: {}
 systemd_mounts_allow_reload: {}

--- a/tasks/systemd_mounts.yml
+++ b/tasks/systemd_mounts.yml
@@ -39,18 +39,19 @@
   template:
     src: systemd.mount.j2
     dest: "/etc/systemd/system/{{ item.value.mount[1:] | replace('-', '\\x2d') | replace('/', '-') }}.mount"
-  with_dict: "{{ systemd_mounts }}"
+  with_dict: "{{ systemd_mounts | ansible.builtin.combine(host_systemd_mounts) }}"
   notify: 
     - Reload systemd
     - Enable systemd mount
-  when: item.key in systemd_mounts_enabled
+  when: item.key in  systemd_mounts_enabled + host_systemd_mounts_enabled
 
 - name: SYSTEMD MOUNT | Setup systemd Service for automount
   template:
     src: systemd.automount.j2
     dest: "/etc/systemd/system/{{ item.value.mount[1:] | replace('-', '\\x2d') | replace('/', '-') }}.automount"
-  with_dict: "{{ systemd_mounts }}"
+  with_dict: "{{ systemd_mounts | ansible.builtin.combine(host_systemd_mounts) }}"
   notify: 
     - Reload systemd
     - Enable systemd automount
-  when: item.value.automount is defined and item.value.automount == true and item.key in systemd_mounts_enabled
+  when: item.value.automount is defined and item.value.automount == true and item.key in  systemd_mounts_enabled + host_systemd_mounts_enabled
+


### PR DESCRIPTION
This'll make it easier to handle circumstances where specific hosts may have mounts defined that aren't necessarily worth dedicating a group to.